### PR TITLE
Try git submobile instead of cloning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .nyc_output/
 coverage/
 dist/
-micromark/
 node_modules/
 *.log
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "micromark"]
+	path = micromark
+	url = https://github.com/micromark/micromark

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "xo": "^0.34.0"
   },
   "scripts": {
-    "prepare": "if [ -d \"micromark\" ] ; then\ncd \"micromark\" && git pull\nelse\ngit clone https://github.com/micromark/micromark.git\nfi",
+    "prepare": "git submodule update --init",
     "format": "remark . -qfo && prettier . -w --loglevel warn && xo --fix",
     "generate-dist": "babel lib/ --out-dir dist/ --quiet --retain-lines --plugins ./micromark/script/babel-transform-constants.js; prettier dist/ --loglevel error --write",
     "generate-size": "browserify . -p tinyify -s mdast-util-from-markdown -o mdast-util-from-markdown.min.js; gzip-size mdast-util-from-markdown.min.js",


### PR DESCRIPTION
Ref https://git-scm.com/book/en/v2/Git-Tools-Submodules

This fixes micromark to specific commit. I used `git checkout 2.10.1`
inside submodule and committed result.

At least nothing will break with new changes in micromark.

<!--

Read the [contributing guidelines](https://github.com/syntax-tree/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/syntax-tree/.github/blob/main/support.md
https://github.com/syntax-tree/.github/blob/main/contributing.md
-->
