### PR TITLE
Fix handling of reference links with inline code

### DIFF
--- a/dev/lib/index.js
+++ b/dev/lib/index.js
@@ -884,7 +884,7 @@ function compiler(options = {}) {
         this.stack[this.stack.length - 1]
       )
 
-    node.label = value
+    node.label = node.identifier
 
     // Assume a reference.
     setData('inReference', true)

--- a/test/index.js
+++ b/test/index.js
@@ -867,6 +867,40 @@ test('mdast-util-from-markdown', (t) => {
   )
 
   t.deepEqual(
+    fromMarkdown('[`a`][]\n\n[`a`]: b').children[0],
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'linkReference',
+          children: [
+            {
+              type: 'inlineCode',
+              value: 'a',
+              position: {
+                start: {line: 1, column: 2, offset: 1},
+                end: {line: 1, column: 5, offset: 4}
+              }
+            }
+          ],
+          position: {
+            start: {line: 1, column: 1, offset: 0},
+            end: {line: 1, column: 8, offset: 7}
+          },
+          identifier: '`a`',
+          label: '`a`',
+          referenceType: 'collapsed'
+        }
+      ],
+      position: {
+        start: {line: 1, column: 1, offset: 0},
+        end: {line: 1, column: 8, offset: 7}
+      }
+    },
+    'should parse a link (collapsed reference) with inline code in the label'
+  )
+
+  t.deepEqual(
     fromMarkdown('[a][b]\n\n[b]: c').children[0],
     {
       type: 'paragraph',


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This fixes the AST so that certain kinds of reference links are not
broken when converted back to markdown.

Fixes: https://github.com/remarkjs/remark/issues/850

<!--do not edit: pr-->
