### PR TITLE
Fix handling of reference links with inline code

### DIFF
--- a/dev/lib/index.js
+++ b/dev/lib/index.js
@@ -85,6 +85,7 @@ import {parse} from 'micromark/lib/parse.js'
 import {preprocess} from 'micromark/lib/preprocess.js'
 import {postprocess} from 'micromark/lib/postprocess.js'
 import {decodeNumericCharacterReference} from 'micromark-util-decode-numeric-character-reference'
+import {decodeString} from 'micromark-util-decode-string'
 import {normalizeIdentifier} from 'micromark-util-normalize-identifier'
 import {codes} from 'micromark-util-symbol/codes.js'
 import {constants} from 'micromark-util-symbol/constants.js'
@@ -866,13 +867,14 @@ function compiler(options = {}) {
 
   /** @type {Handle} */
   function onexitlabeltext(token) {
-    const ancestor = /** @type {(Link|Image) & {identifier: string}} */ (
-      this.stack[this.stack.length - 2]
-    )
+    const ancestor =
+      /** @type {(Link|Image) & {identifier: string, label: string}} */ (
+        this.stack[this.stack.length - 2]
+      )
+    const string = this.sliceSerialize(token)
 
-    ancestor.identifier = normalizeIdentifier(
-      this.sliceSerialize(token)
-    ).toLowerCase()
+    ancestor.label = decodeString(string)
+    ancestor.identifier = normalizeIdentifier(string).toLowerCase()
   }
 
   /** @type {Handle} */
@@ -883,8 +885,6 @@ function compiler(options = {}) {
       /** @type {(Link|Image) & {identifier: string, label: string}} */ (
         this.stack[this.stack.length - 1]
       )
-
-    node.label = node.identifier
 
     // Assume a reference.
     setData('inReference', true)

--- a/dev/lib/index.js
+++ b/dev/lib/index.js
@@ -884,7 +884,7 @@ function compiler(options = {}) {
         this.stack[this.stack.length - 1]
       )
 
-    node.label = value
+    node.label = node.identifier
 
     // Assume a reference.
     setData('inReference', true)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mdast-util-to-string": "^3.1.0",
     "micromark": "^3.0.0",
     "micromark-util-decode-numeric-character-reference": "^1.0.0",
+    "micromark-util-decode-string": "^1.0.0",
     "micromark-util-normalize-identifier": "^1.0.0",
     "micromark-util-symbol": "^1.0.0",
     "micromark-util-types": "^1.0.0",

--- a/test/fixtures/link-reference-with-phrasing.json
+++ b/test/fixtures/link-reference-with-phrasing.json
@@ -1,0 +1,563 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "children": [
+            {
+              "type": "inlineCode",
+              "value": "f",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 2,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 5,
+                  "offset": 4
+                }
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 8,
+              "offset": 7
+            }
+          },
+          "identifier": "`f`",
+          "label": "`f`",
+          "referenceType": "collapsed"
+        },
+        {
+          "type": "text",
+          "value": "\n",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 8,
+              "offset": 7
+            },
+            "end": {
+              "line": 2,
+              "column": 1,
+              "offset": 8
+            }
+          }
+        },
+        {
+          "type": "linkReference",
+          "children": [
+            {
+              "type": "text",
+              "value": ";",
+              "position": {
+                "start": {
+                  "line": 2,
+                  "column": 2,
+                  "offset": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 7,
+                  "offset": 14
+                }
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 2,
+              "column": 1,
+              "offset": 8
+            },
+            "end": {
+              "line": 2,
+              "column": 11,
+              "offset": 18
+            }
+          },
+          "identifier": "&semi;",
+          "label": ";",
+          "referenceType": "collapsed"
+        },
+        {
+          "type": "text",
+          "value": "\n",
+          "position": {
+            "start": {
+              "line": 2,
+              "column": 11,
+              "offset": 18
+            },
+            "end": {
+              "line": 3,
+              "column": 1,
+              "offset": 19
+            }
+          }
+        },
+        {
+          "type": "linkReference",
+          "children": [
+            {
+              "type": "text",
+              "value": ";",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 2,
+                  "offset": 20
+                },
+                "end": {
+                  "line": 3,
+                  "column": 4,
+                  "offset": 22
+                }
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1,
+              "offset": 19
+            },
+            "end": {
+              "line": 3,
+              "column": 7,
+              "offset": 25
+            }
+          },
+          "identifier": "\\;",
+          "label": ";",
+          "referenceType": "collapsed"
+        },
+        {
+          "type": "text",
+          "value": "\n",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 7,
+              "offset": 25
+            },
+            "end": {
+              "line": 4,
+              "column": 1,
+              "offset": 26
+            }
+          }
+        },
+        {
+          "type": "linkReference",
+          "children": [
+            {
+              "type": "text",
+              "value": ";",
+              "position": {
+                "start": {
+                  "line": 4,
+                  "column": 2,
+                  "offset": 27
+                },
+                "end": {
+                  "line": 4,
+                  "column": 3,
+                  "offset": 28
+                }
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 4,
+              "column": 1,
+              "offset": 26
+            },
+            "end": {
+              "line": 4,
+              "column": 6,
+              "offset": 31
+            }
+          },
+          "identifier": ";",
+          "label": ";",
+          "referenceType": "collapsed"
+        },
+        {
+          "type": "text",
+          "value": "\n",
+          "position": {
+            "start": {
+              "line": 4,
+              "column": 6,
+              "offset": 31
+            },
+            "end": {
+              "line": 5,
+              "column": 1,
+              "offset": 32
+            }
+          }
+        },
+        {
+          "type": "linkReference",
+          "children": [
+            {
+              "type": "inlineCode",
+              "value": "f",
+              "position": {
+                "start": {
+                  "line": 5,
+                  "column": 2,
+                  "offset": 33
+                },
+                "end": {
+                  "line": 5,
+                  "column": 5,
+                  "offset": 36
+                }
+              }
+            },
+            {
+              "type": "text",
+              "value": ";",
+              "position": {
+                "start": {
+                  "line": 5,
+                  "column": 5,
+                  "offset": 36
+                },
+                "end": {
+                  "line": 5,
+                  "column": 10,
+                  "offset": 41
+                }
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1,
+              "offset": 32
+            },
+            "end": {
+              "line": 5,
+              "column": 14,
+              "offset": 45
+            }
+          },
+          "identifier": "`f`&semi;",
+          "label": "`f`;",
+          "referenceType": "collapsed"
+        },
+        {
+          "type": "text",
+          "value": "\n",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 14,
+              "offset": 45
+            },
+            "end": {
+              "line": 6,
+              "column": 1,
+              "offset": 46
+            }
+          }
+        },
+        {
+          "type": "linkReference",
+          "children": [
+            {
+              "type": "inlineCode",
+              "value": "f",
+              "position": {
+                "start": {
+                  "line": 6,
+                  "column": 2,
+                  "offset": 47
+                },
+                "end": {
+                  "line": 6,
+                  "column": 5,
+                  "offset": 50
+                }
+              }
+            },
+            {
+              "type": "text",
+              "value": ";",
+              "position": {
+                "start": {
+                  "line": 6,
+                  "column": 5,
+                  "offset": 50
+                },
+                "end": {
+                  "line": 6,
+                  "column": 7,
+                  "offset": 52
+                }
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 6,
+              "column": 1,
+              "offset": 46
+            },
+            "end": {
+              "line": 6,
+              "column": 10,
+              "offset": 55
+            }
+          },
+          "identifier": "`f`\\;",
+          "label": "`f`;",
+          "referenceType": "collapsed"
+        },
+        {
+          "type": "text",
+          "value": "\n",
+          "position": {
+            "start": {
+              "line": 6,
+              "column": 10,
+              "offset": 55
+            },
+            "end": {
+              "line": 7,
+              "column": 1,
+              "offset": 56
+            }
+          }
+        },
+        {
+          "type": "linkReference",
+          "children": [
+            {
+              "type": "inlineCode",
+              "value": "f",
+              "position": {
+                "start": {
+                  "line": 7,
+                  "column": 2,
+                  "offset": 57
+                },
+                "end": {
+                  "line": 7,
+                  "column": 5,
+                  "offset": 60
+                }
+              }
+            },
+            {
+              "type": "text",
+              "value": ";",
+              "position": {
+                "start": {
+                  "line": 7,
+                  "column": 5,
+                  "offset": 60
+                },
+                "end": {
+                  "line": 7,
+                  "column": 6,
+                  "offset": 61
+                }
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 1,
+              "offset": 56
+            },
+            "end": {
+              "line": 7,
+              "column": 9,
+              "offset": 64
+            }
+          },
+          "identifier": "`f`;",
+          "label": "`f`;",
+          "referenceType": "collapsed"
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 9,
+          "offset": 64
+        }
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "`f`",
+      "label": "`f`",
+      "title": null,
+      "url": "alpha",
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 66
+        },
+        "end": {
+          "line": 9,
+          "column": 13,
+          "offset": 78
+        }
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "&semi;",
+      "label": ";",
+      "title": null,
+      "url": "bravo",
+      "position": {
+        "start": {
+          "line": 10,
+          "column": 1,
+          "offset": 79
+        },
+        "end": {
+          "line": 10,
+          "column": 16,
+          "offset": 94
+        }
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "\\;",
+      "label": ";",
+      "title": null,
+      "url": "charlie",
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "offset": 95
+        },
+        "end": {
+          "line": 11,
+          "column": 14,
+          "offset": 108
+        }
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": ";",
+      "label": ";",
+      "title": null,
+      "url": "delta",
+      "position": {
+        "start": {
+          "line": 12,
+          "column": 1,
+          "offset": 109
+        },
+        "end": {
+          "line": 12,
+          "column": 11,
+          "offset": 119
+        }
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "`f`&semi;",
+      "label": "`f`;",
+      "title": null,
+      "url": "echo",
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 120
+        },
+        "end": {
+          "line": 13,
+          "column": 18,
+          "offset": 137
+        }
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "`f`\\;",
+      "label": "`f`;",
+      "title": null,
+      "url": "foxtrot",
+      "position": {
+        "start": {
+          "line": 14,
+          "column": 1,
+          "offset": 138
+        },
+        "end": {
+          "line": 14,
+          "column": 17,
+          "offset": 154
+        }
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "`f`;",
+      "label": "`f`;",
+      "title": null,
+      "url": "golf",
+      "position": {
+        "start": {
+          "line": 15,
+          "column": 1,
+          "offset": 155
+        },
+        "end": {
+          "line": 15,
+          "column": 13,
+          "offset": 167
+        }
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 16,
+      "column": 1,
+      "offset": 168
+    }
+  }
+}

--- a/test/fixtures/link-reference-with-phrasing.md
+++ b/test/fixtures/link-reference-with-phrasing.md
@@ -1,0 +1,15 @@
+[`f`][]
+[&semi;][]
+[\;][]
+[;][]
+[`f`&semi;][]
+[`f`\;][]
+[`f`;][]
+
+[`f`]: alpha
+[&semi;]: bravo
+[\;]: charlie
+[;]: delta
+[`f`&semi;]: echo
+[`f`\;]: foxtrot
+[`f`;]: golf

--- a/test/index.js
+++ b/test/index.js
@@ -867,6 +867,40 @@ test('mdast-util-from-markdown', (t) => {
   )
 
   t.deepEqual(
+    fromMarkdown('[`a`][]\n\n[`a`]: b').children[0],
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'linkReference',
+          children: [
+            {
+              type: 'inlineCode',
+              value: 'a',
+              position: {
+                start: {line: 1, column: 2, offset: 1},
+                end: {line: 1, column: 5, offset: 4}
+              }
+            }
+          ],
+          position: {
+            start: {line: 1, column: 1, offset: 0},
+            end: {line: 1, column: 8, offset: 7}
+          },
+          identifier: '`a`',
+          label: '`a`',
+          referenceType: 'collapsed'
+        }
+      ],
+      position: {
+        start: {line: 1, column: 1, offset: 0},
+        end: {line: 1, column: 8, offset: 7}
+      }
+    },
+    'should parse a link (collapsed reference) with inline code in the label'
+  )
+
+  t.deepEqual(
     fromMarkdown('[a][b]\n\n[b]: c').children[0],
     {
       type: 'paragraph',


### PR DESCRIPTION
This fixes the AST so that certain kinds of reference links are not
broken when converted back to markdown.

Fixes: https://github.com/remarkjs/remark/issues/850<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This fixes text content (“phrasing”, such as emphasis or code) inside labels (of links, images).

<!--do not edit: pr-->
