### PR TITLE
Add template literal tag

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -9,4 +9,4 @@
  * @typedef {import('./lib/index.js').CompileContext} CompileContext
  */
 
-export {fromMarkdown} from './lib/index.js'
+export {fromMarkdown, md} from './lib/index.js'

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@types/mdast": "^3.0.0",
     "@types/unist": "^2.0.0",
-    "mdast-util-directive": "^2.1.1",
     "mdast-util-to-string": "^3.1.0",
     "micromark": "^3.0.0",
     "micromark-extension-directive": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,10 @@
   "dependencies": {
     "@types/mdast": "^3.0.0",
     "@types/unist": "^2.0.0",
+    "mdast-util-directive": "^2.1.1",
     "mdast-util-to-string": "^3.1.0",
     "micromark": "^3.0.0",
+    "micromark-extension-directive": "^2.0.1",
     "micromark-util-decode-numeric-character-reference": "^1.0.0",
     "micromark-util-decode-string": "^1.0.0",
     "micromark-util-normalize-identifier": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/unist": "^2.0.0",
     "mdast-util-to-string": "^3.1.0",
     "micromark": "^3.0.0",
-    "micromark-extension-directive": "^2.0.1",
     "micromark-util-decode-numeric-character-reference": "^1.0.0",
     "micromark-util-decode-string": "^1.0.0",
     "micromark-util-normalize-identifier": "^1.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -3,9 +3,9 @@
  */
 
 import assert from 'assert'
-import {Buffer} from 'node:buffer'
 import fs from 'fs'
 import path from 'path'
+import {Buffer} from 'node:buffer'
 import test from 'tape'
 import {unified} from 'unified'
 import rehypeParse from 'rehype-parse'
@@ -14,7 +14,7 @@ import {toHast} from 'mdast-util-to-hast'
 import {toString} from 'mdast-util-to-string'
 import {toHtml} from 'hast-util-to-html'
 import {commonmark} from 'commonmark.json'
-import {fromMarkdown} from '../dev/index.js'
+import {fromMarkdown, md} from '../dev/index.js'
 
 const join = path.join
 
@@ -1010,6 +1010,55 @@ test('mdast-util-from-markdown', (t) => {
       }
     },
     'should parse a thematic break'
+  )
+
+  t.deepEqual(
+    md`*${fromMarkdown('a*b')}*`.children[0],
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'emphasis',
+          children: [
+            {
+              type: 'root',
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'a*b',
+                      position: {
+                        start: {line: 1, column: 1, offset: 0},
+                        end: {line: 1, column: 4, offset: 3}
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {line: 1, column: 1, offset: 0},
+                    end: {line: 1, column: 4, offset: 3}
+                  }
+                }
+              ],
+              position: {
+                start: {line: 1, column: 1, offset: 0},
+                end: {line: 1, column: 4, offset: 3}
+              }
+            }
+          ],
+          position: {
+            start: {line: 1, column: 1, offset: 0},
+            end: {line: 1, column: 14, offset: 13}
+          }
+        }
+      ],
+      position: {
+        start: {line: 1, column: 1, offset: 0},
+        end: {line: 1, column: 14, offset: 13}
+      }
+    },
+    'should substitute an expression'
   )
 
   t.end()

--- a/test/index.js
+++ b/test/index.js
@@ -1049,13 +1049,13 @@ test('mdast-util-from-markdown', (t) => {
           ],
           position: {
             start: {line: 1, column: 1, offset: 0},
-            end: {line: 1, column: 14, offset: 13}
+            end: {line: 1, column: 4, offset: 3}
           }
         }
       ],
       position: {
         start: {line: 1, column: 1, offset: 0},
-        end: {line: 1, column: 14, offset: 13}
+        end: {line: 1, column: 4, offset: 3}
       }
     },
     'should substitute an expression'


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

What do you think about adding a template literal tag, perhaps like so?

It allows me to wrap an existing mdast AST in a Markdown "template". For example:
```javascript
import { md } from "mdast-util-from-markdown";

const text = md`a*b`;
const emphasis = md`*${text}*`;
console.dir(emphasis, { depth: null });
```
<details><summary>Combined AST:</summary>

```javascript
{
  type: 'root',
  children: [
    {
      type: 'paragraph',
      children: [
        {
          type: 'emphasis',
          children: [
            {
              type: 'root',
              children: [
                {
                  type: 'paragraph',
                  children: [
                    {
                      type: 'text',
                      value: 'a*b',
                      position: {
                        start: { line: 1, column: 1, offset: 0 },
                        end: { line: 1, column: 4, offset: 3 }
                      }
                    }
                  ],
                  position: {
                    start: { line: 1, column: 1, offset: 0 },
                    end: { line: 1, column: 4, offset: 3 }
                  }
                }
              ],
              position: {
                start: { line: 1, column: 1, offset: 0 },
                end: { line: 1, column: 4, offset: 3 }
              }
            }
          ],
          position: {
            start: { line: 1, column: 1, offset: 0 },
            end: { line: 1, column: 14, offset: 13 }
          }
        }
      ],
      position: {
        start: { line: 1, column: 1, offset: 0 },
        end: { line: 1, column: 14, offset: 13 }
      }
    }
  ],
  position: {
    start: { line: 1, column: 1, offset: 0 },
    end: { line: 1, column: 14, offset: 13 }
  }
}
```
</details>

Possible approaches discussed in: https://github.com/syntax-tree/unist/discussions/54

The approach in this PR is tentatively [mdast-util-directive](https://github.com/syntax-tree/mdast-util-directive): It interleaves the template strings with `:expression`, parses, then walks the result and swaps the `:expression` nodes for the template args. 

<!--do not edit: pr-->
