### PR TITLE
fix ESM exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
     "index.js"
   ],
   "exports": {
-    "development": "./dev/index.js",
-    "default": "./index.js"
+    "./development": "./dev/index.js",
+    "./lib": "./lib/index.js",
+    ".": "./index.js"
   },
   "dependencies": {
     "@types/mdast": "^3.0.0",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [N/A] If applicable, I’ve added docs and tests

### Description of changes

Following up on https://github.com/syntax-tree/mdast-util-from-markdown/commit/309f2a46e940357f4a8068c09cd4c15d91cb8c55 .. cc @wooorm 

Per the NodeJS Spec: https://nodejs.org/api/packages.html#package-entry-points

> When using the ["exports"](https://nodejs.org/api/packages.html#exports) field, custom subpaths can be defined along with the main entry point by treating the main entry point as the "." subpath

This PR updates `package.json` to use the new syntax (starting with a dot).

It  also export the `lib/index.js` path, which is required to properly propagate the generated types from `lib/index.d.ts` to the root `index.d.ts` that re-exports its. This is already breaking builds in dependents that use `"moduleResolution": "node16"` in their `tsconfig.json`. Example I found today in `remark-parse` latest version:

```log
node_modules/remark-parse/lib/index.d.ts:3:26 - error TS2307: Cannot find module 'mdast-util-from-markdown/lib' or its corresponding type declarations.

3   options: void | import('mdast-util-from-markdown/lib').Options | undefined

Found 1 error in node_modules/remark-parse/lib/index.d.ts:3
```

<!--do not edit: pr-->
