### PR TITLE
Allow extension handlers to fall through to default logic

### DIFF
--- a/dev/lib/index.js
+++ b/dev/lib/index.js
@@ -1309,9 +1309,15 @@ function extension(combined, extension) {
 
         case 'enter':
         case 'exit': {
+          const left = combined[key]
           const right = extension[key]
-          if (right) {
-            Object.assign(combined[key], right)
+          for (const tokenType in right) {
+            if (right[tokenType]) {
+              left[tokenType] = combineHandles(
+                left[tokenType],
+                right[tokenType]
+              )
+            }
           }
 
           break
@@ -1319,6 +1325,22 @@ function extension(combined, extension) {
         // No default
       }
     }
+  }
+}
+
+/**
+ * Creates a new handle that calls `right` first, then falls through to `left`
+ * only if `right` explicitly returns `false`.
+ * @param {Handle?} left
+ * @param {Handle} right
+ * @returns {Handle}
+ */
+function combineHandles(left, right) {
+  if (!left) return right
+
+  return function (...params) {
+    const rightResult = right.apply(this, params)
+    return rightResult === false ? left.apply(this, params) : rightResult
   }
 }
 

--- a/dev/lib/index.js
+++ b/dev/lib/index.js
@@ -1338,9 +1338,9 @@ function extension(combined, extension) {
 function combineHandles(left, right) {
   if (!left) return right
 
-  return function (...params) {
-    const rightResult = right.apply(this, params)
-    return rightResult === false ? left.apply(this, params) : rightResult
+  return function (...parameters) {
+    const rightResult = right.apply(this, parameters)
+    return rightResult === false ? left.apply(this, parameters) : rightResult
   }
 }
 

--- a/dev/lib/types.d.ts
+++ b/dev/lib/types.d.ts
@@ -229,7 +229,10 @@ export type Handles = Record<string, Handle>
  *   Nothing, if the token was fully handled by this extension and should be ignored by previous extensions / default logic.
  *   Or `false`, if the token has not been handled by this extension and handling should fall back to preceding logic.
  */
-export type Handle = (this: CompileContext, token: Token) => undefined | void | false
+export type Handle = (
+  this: CompileContext,
+  token: Token
+) => undefined | void | false
 
 /**
  * Handle the case where the `right` token is open, but it is closed (by the

--- a/dev/lib/types.d.ts
+++ b/dev/lib/types.d.ts
@@ -226,9 +226,10 @@ export type Handles = Record<string, Handle>
  * @param token
  *   Current token.
  * @returns
- *   Nothing.
+ *   Nothing, if the token was fully handled by this extension and should be ignored by previous extensions / default logic.
+ *   Or `false`, if the token has not been handled by this extension and handling should fall back to preceding logic.
  */
-export type Handle = (this: CompileContext, token: Token) => undefined | void
+export type Handle = (this: CompileContext, token: Token) => undefined | void | false
 
 /**
  * Handle the case where the `right` token is open, but it is closed (by the

--- a/readme.md
+++ b/readme.md
@@ -249,8 +249,9 @@ Handle a token (TypeScript type).
 ###### Returns
 
 Nothing, if the token was fully handled and should be ignored by previous
-extensions / default logic. Or `false`, if the token has not been handled here
-and the parser should fall back to preceding logic.
+extensions / default logic.
+Or `false`, if the token has not been handled here and the parser should fall
+back to preceding logic.
 
 ### `OnEnterError`
 

--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,9 @@ Handle a token (TypeScript type).
 
 ###### Returns
 
-Nothing (`undefined`).
+Nothing, if the token was fully handled and should be ignored by previous
+extensions / default logic. Or `false`, if the token has not been handled here
+and the parser should fall back to preceding logic.
 
 ### `OnEnterError`
 

--- a/test/index.js
+++ b/test/index.js
@@ -146,6 +146,51 @@ test('fromMarkdown', async function (t) {
     )
   })
 
+  await t.test(
+    'should allow extension handlers to fall through',
+    async function () {
+      assert.deepEqual(
+        fromMarkdown('a\nb', {
+          mdastExtensions: [
+            {
+              enter: {
+                paragraph() {
+                  return false
+                }
+              }
+            }
+          ]
+        }),
+        {
+          type: 'root',
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'text',
+                  value: 'a\nb',
+                  position: {
+                    start: {line: 1, column: 1, offset: 0},
+                    end: {line: 2, column: 2, offset: 3}
+                  }
+                }
+              ],
+              position: {
+                start: {line: 1, column: 1, offset: 0},
+                end: {line: 2, column: 2, offset: 3}
+              }
+            }
+          ],
+          position: {
+            start: {line: 1, column: 1, offset: 0},
+            end: {line: 2, column: 2, offset: 3}
+          }
+        }
+      )
+    }
+  )
+
   await t.test('should support multiple extensions', async function () {
     assert.deepEqual(
       fromMarkdown('a\nb', {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

TLDR: Adds support for extensions' `enter` and `exit` handlers to return `false` to fall back to earlier extensions or the default logic. 

#### Context

I am working on a project where I'd like to attach additional information to nodes based on the information already in the tokenization output. In this particular case, I'm trying to record data about the specific syntax that formed a node in the tree (essentially building a sort of concrete syntax tree on top of the AST). 

While building an extension that provides handlers for the relevant syntax tokens and attaches them to nodes in the stack, I noticed that I was breaking the built-in parsing functionality. Upon digging I realized that this was because my `enter` handlers were overriding and disabling the default handlers, even though I only wanted to encounter the tokens without doing the parsing and tree building myself. 

I realized that a very useful feature of extension handlers would be the ability to 'fall through' to the default behavior if desired. To me the most intuitive approach for this was to support returning `false` to indicate that a token was not handled by the handler. This is a flexible API that allows for handlers to fall through conditionally, allowing them to choose to only take over the handling of a token in certain circumstances.  

Since the code change here is fairly straightforward, I chose to go ahead and open a PR rather than start with an issue. I am very open to feedback here and happy to change the approach or reject the change entirely if you don't think it's useful. 

<!--do not edit: pr-->
