### PR TITLE
perf(compile): pre-declare position in node factories

### DIFF
--- a/dev/lib/index.js
+++ b/dev/lib/index.js
@@ -212,7 +212,7 @@ function compiler(options) {
    */
   function compile(events) {
     /** @type {Root} */
-    let tree = {type: 'root', children: []}
+    let tree = {type: 'root', children: [], position: undefined}
     /** @type {Omit<CompileContext, 'sliceSerialize'>} */
     const context = {
       stack: [tree],
@@ -1137,19 +1137,31 @@ function compiler(options) {
   // Creaters.
   //
 
+  // Each node factory pre-declares `position` as undefined as the trailing
+  // property. enter() patches it to a real value, but the property already
+  // exists, so V8 sees a single hidden class for each node type from
+  // construction through the rest of the pipeline. Without the pre-declare,
+  // each node took a hidden-class transition when enter() added position.
+
   /** @returns {Blockquote} */
   function blockQuote() {
-    return {type: 'blockquote', children: []}
+    return {type: 'blockquote', children: [], position: undefined}
   }
 
   /** @returns {Code} */
   function codeFlow() {
-    return {type: 'code', lang: null, meta: null, value: ''}
+    return {
+      type: 'code',
+      lang: null,
+      meta: null,
+      value: '',
+      position: undefined
+    }
   }
 
   /** @returns {InlineCode} */
   function codeText() {
-    return {type: 'inlineCode', value: ''}
+    return {type: 'inlineCode', value: '', position: undefined}
   }
 
   /** @returns {Definition} */
@@ -1159,13 +1171,14 @@ function compiler(options) {
       identifier: '',
       label: null,
       title: null,
-      url: ''
+      url: '',
+      position: undefined
     }
   }
 
   /** @returns {Emphasis} */
   function emphasis() {
-    return {type: 'emphasis', children: []}
+    return {type: 'emphasis', children: [], position: undefined}
   }
 
   /** @returns {Heading} */
@@ -1174,28 +1187,41 @@ function compiler(options) {
       type: 'heading',
       // @ts-expect-error `depth` will be set later.
       depth: 0,
-      children: []
+      children: [],
+      position: undefined
     }
   }
 
   /** @returns {Break} */
   function hardBreak() {
-    return {type: 'break'}
+    return {type: 'break', position: undefined}
   }
 
   /** @returns {Html} */
   function html() {
-    return {type: 'html', value: ''}
+    return {type: 'html', value: '', position: undefined}
   }
 
   /** @returns {Image} */
   function image() {
-    return {type: 'image', title: null, url: '', alt: null}
+    return {
+      type: 'image',
+      title: null,
+      url: '',
+      alt: null,
+      position: undefined
+    }
   }
 
   /** @returns {Link} */
   function link() {
-    return {type: 'link', title: null, url: '', children: []}
+    return {
+      type: 'link',
+      title: null,
+      url: '',
+      children: [],
+      position: undefined
+    }
   }
 
   /**
@@ -1208,7 +1234,8 @@ function compiler(options) {
       ordered: token.type === 'listOrdered',
       start: null,
       spread: token._spread,
-      children: []
+      children: [],
+      position: undefined
     }
   }
 
@@ -1221,28 +1248,29 @@ function compiler(options) {
       type: 'listItem',
       spread: token._spread,
       checked: null,
-      children: []
+      children: [],
+      position: undefined
     }
   }
 
   /** @returns {Paragraph} */
   function paragraph() {
-    return {type: 'paragraph', children: []}
+    return {type: 'paragraph', children: [], position: undefined}
   }
 
   /** @returns {Strong} */
   function strong() {
-    return {type: 'strong', children: []}
+    return {type: 'strong', children: [], position: undefined}
   }
 
   /** @returns {Text} */
   function text() {
-    return {type: 'text', value: ''}
+    return {type: 'text', value: '', position: undefined}
   }
 
   /** @returns {ThematicBreak} */
   function thematicBreak() {
-    return {type: 'thematicBreak'}
+    return {type: 'thematicBreak', position: undefined}
   }
 }
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Each node factory returned an object literal that did not include a position property. enter() then patched the property in. V8 treated the property addition as a hidden-class transition for every node, so property reads in enter, exit, the compile loop, and any consumer walked a polymorphic shape instead of a stable one.

The fix declares 'position: undefined' as the trailing property on every node factory and on the root tree literal. enter() still mutates position to a real value, but the property already exists, so no hidden-class transition fires. V8 keeps a single hidden class per node type from construction onward.

Inputs that benefit, with multi-run median-of-medians vs the baseline (spread in parentheses):

  10,000 character entity references     -27.7%  (1.2%, very clean)
  1,000 fenced code blocks               -29.9%  (13.6%, borderline)
  CommonMark spec * 35  (~564 KB)         -9.3%  (6.9%)
  one CommonMark example                  -7.5%  (9.5%)
  full CommonMark spec  (~16 KB)          -6.3%  (8.3%)
  CommonMark spec * 7  (~113 KB)          -2.2%  (7.7%)

Single-run full corpus shows the same direction across every input that creates a non-trivial number of nodes: a 1,000-image input -25.9%, a 1,000-link input -24.9%, a 5,000-tab-heavy input -22.4%, a 5,000-HTML-block input -11.6%, a 10,000-list-item input -10.3%, a 5,000-heading input -9.4%, a 10,000-code-span input -8.8%, a 1,000-emphasis-chain input -4.7%, the 'xxxx' x 10,000 input -6.5%, a 1,000-autolink input -5.6%.

Trade-offs:

In exchange for stable hidden classes, every node now carries a 'position: undefined' field even when position would never have been added. In practice every node in this codebase gets a real position assigned by enter(), so the only cost is one undefined slot for the brief window between factory and enter() call.

Inputs where the gain is small or absent:

A 1 MB single paragraph reported +2.9% on a single run. That input produces one giant text node whose hidden-class shape was already monomorphic, so the change has no benefit there and the small move sits inside the input's noise band. A 5,000-reference-link-definition input and a 10,000-unmatched-asterisks input each moved +/- 2% on a single run, also inside their respective noise bands. Multi-run showed legacy-defs at -0.0% (clean, no movement).

The pure emphasis stress inputs ('a**b' repeated 10,000 times and similar) reported +17% to +29% on single runs but their cross-run spread is 12 to 50% on this stack alone, and these inputs do not exercise the node-creation hot path that this change targets, so the deltas are noise.

Tests pass: dev + prod 1448/1448, mdast-util-gfm 54/54, mdast-util-mdx 11/13. The two failing mdx tests reproduce on upstream/main and are not introduced by this branch.

<!--do not edit: pr-->
