### PR TITLE
build: replace c8 with Node's native test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,17 +8,13 @@ jobs:
         with:
           node-version: ${{matrix.node}}
       - run: npm install
-      - run: npm run ${{matrix.test-cmd}}
+      - run: npm run test-strict
       - uses: codecov/codecov-action@v5
     strategy:
       matrix:
-        include:
-          - node: lts/iron
-            test-cmd: test
-          - node: lts/jod
-            test-cmd: test-strict
-          - node: lts/*
-            test-cmd: test-strict
+        node:
+          - lts/*
+          - node
 name: main
 on:
   - pull_request

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,17 @@ jobs:
         with:
           node-version: ${{matrix.node}}
       - run: npm install
-      - run: npm test
+      - run: npm run ${{matrix.test-cmd}}
       - uses: codecov/codecov-action@v5
     strategy:
       matrix:
-        node:
-          - lts/iron
-          - node
+        include:
+          - node: lts/iron
+            test-cmd: test
+          - node: lts/jod
+            test-cmd: test-strict
+          - node: lts/*
+            test-cmd: test-strict
 name: main
 on:
   - pull_request

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
         with:
           node-version: ${{matrix.node}}
       - run: npm install
-      - run: npm run test-strict
+      - run: npm test
       - uses: codecov/codecov-action@v5
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test-api-prod": "node --conditions production test/index.js",
     "test-api": "npm run test-api-dev && npm run test-api-prod",
     "test-coverage": "node --experimental-test-coverage --conditions development test/index.js && node --experimental-test-coverage --conditions production test/index.js",
-    "test-coverage-strict": "node --experimental-test-coverage --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions development test/index.js && node --experimental-test-coverage --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions production test/index.js",
+    "test-coverage-strict": "node --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions development test/index.js && node --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions production test/index.js",
     "test": "npm run build && npm run format && npm run test-coverage",
     "test-strict": "npm run build && npm run format && npm run test-coverage-strict"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "description": "mdast utility to parse markdown",
   "devDependencies": {
     "@types/node": "^25.0.0",
-    "c8": "^10.0.0",
     "commonmark.json": "^0.31.0",
     "esbuild": "^0.27.0",
     "gzip-size-cli": "^5.0.0",
@@ -86,7 +85,7 @@
     "test-api-dev": "node --conditions development test/index.js",
     "test-api-prod": "node --conditions production test/index.js",
     "test-api": "npm run test-api-dev && npm run test-api-prod",
-    "test-coverage": "c8 --100 --reporter lcov -- npm run test-api",
+    "test-coverage": "node --experimental-test-coverage --conditions development test/index.js && node --experimental-test-coverage --conditions production test/index.js",
     "test": "npm run build && npm run format && npm run test-coverage"
   },
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -85,10 +85,8 @@
     "test-api-dev": "node --conditions development test/index.js",
     "test-api-prod": "node --conditions production test/index.js",
     "test-api": "npm run test-api-dev && npm run test-api-prod",
-    "test-coverage": "node --experimental-test-coverage --conditions development test/index.js && node --experimental-test-coverage --conditions production test/index.js",
-    "test-coverage-strict": "node --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions development test/index.js && node --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions production test/index.js",
-    "test": "npm run build && npm run format && npm run test-coverage",
-    "test-strict": "npm run build && npm run format && npm run test-coverage-strict"
+    "test-coverage": "node --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions development test/index.js && node --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions production test/index.js",
+    "test": "npm run build && npm run format && npm run test-coverage"
   },
   "sideEffects": false,
   "typeCoverage": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,9 @@
     "test-api-prod": "node --conditions production test/index.js",
     "test-api": "npm run test-api-dev && npm run test-api-prod",
     "test-coverage": "node --experimental-test-coverage --conditions development test/index.js && node --experimental-test-coverage --conditions production test/index.js",
-    "test": "npm run build && npm run format && npm run test-coverage"
+    "test-coverage-strict": "node --experimental-test-coverage --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions development test/index.js && node --experimental-test-coverage --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --conditions production test/index.js",
+    "test": "npm run build && npm run format && npm run test-coverage",
+    "test-strict": "npm run build && npm run format && npm run test-coverage-strict"
   },
   "sideEffects": false,
   "typeCoverage": {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Drop the `c8` dev dependency and run coverage through Node's built-in
`node --experimental-test-coverage` instead. This is split out of #51 so
that PR can stay focused on the `prepareList` performance fix; this PR
carries only the coverage and CI tooling change.

## Problem

`c8` shells through `yargs`, and `c8` calls `require('yargs/yargs')` at
runtime. yargs declares `"type": "module"`, and its `./yargs` subpath
resolves `require` to an extensionless file that itself uses `require()`.
Under the Node 22.20+/24/26 module-loader tightening, that extensionless
file is loaded as ESM, so the run dies before any test executes:

    ReferenceError: require is not defined in ES module scope

The CI matrix includes `node` (latest, currently v26), so the
latest-Node leg fails outright. See nodejs/node#60290 and yargs#2418 for
the upstream behaviour.

## Approach

This package is ESM-only and already runs on the built-in `node:test`
runner, so there is no reason to route coverage through a CJS tool. Node
has reported V8 coverage since v18.19, and the
`--test-coverage-lines/branches/functions` threshold flags that restore
the 100% gate have been available since v22.8.0 and are stable on v24+.
Removing `c8` drops a dependency and the yargs failure mode with it.

PR #51 takes the other route for the same yargs breakage, pinning yargs
via an override so it can keep `c8` and ship without a Node bump. This PR
is the longer-term migration to native coverage and accepts the higher
Node floor.

## Changes

- `package.json`: remove `c8` from devDependencies.
- `package.json`: replace the `test-coverage` script with two direct
  `node --experimental-test-coverage` invocations (development and
  production conditions), each gated at 100% lines, branches, and
  functions, with `--test-coverage-exclude='test/**'` so only source is
  measured.
- `.github/workflows/main.yml`: bump the LTS matrix leg from `lts/iron`
  (Node 20) to `lts/*` (latest LTS, currently Node 24); the `node`
  (latest, currently 26) leg is unchanged.

## Node version support

The native threshold flags require Node v22.8.0+, and a clean 100% only
holds on Node 24+. On Node 22 the runner includes `test/index.js` in the
sweep by default and reports ~99.x%, and its exclusion defaults differ
from Node 24, so 22 is not a reliable target. The matrix therefore runs
`lts/*` (24) and `node` (26).

This is a dev and CI change only. The library's runtime code is
untouched, so published consumers are unaffected. It does drop CI
verification on Node 18/20/22, so the project can no longer promise those
versions; the maintainers may want to land this as a major for that
reason.


<!--do not edit: pr-->
